### PR TITLE
Fix Cloudbuild $HOME override, update Earthfile to 0.7

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -1,4 +1,4 @@
-VERSION 0.7
+VERSION 0.8
 
 FROM golang:1.16-alpine3.13
 WORKDIR /go-example

--- a/Earthfile
+++ b/Earthfile
@@ -1,3 +1,5 @@
+VERSION 0.7
+
 FROM golang:1.16-alpine3.13
 WORKDIR /go-example
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,6 +11,7 @@ steps:
     name: 'earthly/earthly:v0.7.23'
     env:
       - "HOME=/root"
+      - "EARTHLY_PROJECT=cloud"
     args:
       - +gcp-cloudbuild
     secretEnv:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,14 +1,16 @@
 steps:
   - id: 'build'
-    name: 'earthly/earthly:v0.7.23'
+    name: 'earthly/earthly:v0.8.0'
     env:
       - "HOME=/root"
     args:
       - --allow-privileged
+      - --ci
+      - --push
       - +docker
   
   - id: 'gcp-test'
-    name: 'earthly/earthly:v0.7.23'
+    name: 'earthly/earthly:v0.8.0'
     env:
       - "HOME=/root"
       - "EARTHLY_PROJECT=cloud"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,12 +1,16 @@
 steps:
   - id: 'build'
-    name: 'earthly/earthly:v0.5.24'
+    name: 'earthly/earthly:v0.7.23'
+    env:
+      - "HOME=/root"
     args:
       - --allow-privileged
       - +docker
   
   - id: 'gcp-test'
-    name: 'earthly/earthly:v0.5.24'
+    name: 'earthly/earthly:v0.7.23'
+    env:
+      - "HOME=/root"
     args:
       - +gcp-cloudbuild
     secretEnv:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,9 +6,15 @@ steps:
     args:
       - --allow-privileged
       - --ci
-      - --push
+      # - --push # Uncomment to allow GCP to push images to your choice of repository. Secrets for your repository must be configured.
       - +docker
   
+  - id: 'secrets'
+    name: 'earthly/earthly:v0.8.0'
+    entrypoint: earthly secrets ls
+    secretEnv:
+      - 'EARTHLY_TOKEN'
+
   - id: 'gcp-test'
     name: 'earthly/earthly:v0.8.0'
     env:


### PR DESCRIPTION
GCP sets `$HOME` to `/builder/root`. Our entrypoint assumes a home of `/root`, and uses that to set up links to the mTLS certs between `earthly` and `buildkitd`. With the change in `$HOME`, `buildkitd` would fail to start, resulting in an apparent timeout.

This implements a workaround in the example until we can fix the entrypoint.